### PR TITLE
Use telia oss regional buckets

### DIFF
--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -7,7 +7,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   s3_bucket = "${var.filename == "" && var.s3_bucket == "" ? "telia-oss-${data.aws_region.current.name}" : var.s3_bucket}"
-  s3_key    = "${var.filename == "" && var.s3_key == "" ? "concourse-sts-lambda/v0.4.1.zip" : var.s3_key}"
+  s3_key    = "${var.filename == "" && var.s3_key == "" ? "concourse-sts-lambda/v0.5.0.zip" : var.s3_key}"
 }
 
 module "lambda" {

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -5,14 +5,19 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+locals {
+  s3_bucket = "${var.filename == "" && var.s3_bucket == "" ? "telia-oss-${data.aws_region.current.name}" : var.s3_bucket}"
+  s3_key    = "${var.filename == "" && var.s3_key == "" ? "concourse-sts-lambda/v0.4.1.zip" : var.s3_key}"
+}
+
 module "lambda" {
   source  = "telia-oss/lambda/aws"
-  version = "0.3.0"
+  version = "0.3.1"
 
   name_prefix = "${var.name_prefix}"
   filename    = "${var.filename}"
-  s3_bucket   = "${var.s3_bucket}"
-  s3_key      = "${var.s3_key}"
+  s3_bucket   = "${local.s3_bucket}"
+  s3_key      = "${local.s3_key}"
   policy      = "${data.aws_iam_policy_document.lambda.json}"
   handler     = "main"
   runtime     = "go1.x"

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -12,12 +12,12 @@ variable "filename" {
 
 variable "s3_bucket" {
   description = "The bucket where the lambda function is uploaded."
-  default     = "telia-oss"
+  default     = ""
 }
 
 variable "s3_key" {
   description = "The s3 key for the Lambda artifact."
-  default     = "concourse-sts-lambda/v0.4.0.zip"
+  default     = ""
 }
 
 variable "role_prefix" {


### PR DESCRIPTION
The goal of this PR is to be able to deploy the Lambda function in any region and use the prebuilt `telia-oss` artifacts (if `s3_bucket` and `filename` are left blank).