### PR TITLE
Bump s3 key to next release

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default. Unless we have a more specific match.
-*       @itsdalmo
+*       @telia-oss/concourse-owners

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -7,7 +7,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   s3_bucket = "${var.filename == "" && var.s3_bucket == "" ? "telia-oss-${data.aws_region.current.name}" : var.s3_bucket}"
-  s3_key    = "${var.filename == "" && var.s3_key == "" ? "concourse-sts-lambda/v0.5.0.zip" : var.s3_key}"
+  s3_key    = "${var.filename == "" && var.s3_key == "" ? "concourse-sts-lambda/v0.8.0.zip" : var.s3_key}"
 }
 
 module "lambda" {


### PR DESCRIPTION
Intentionally skipping minor versions here to stay in line with https://github.com/telia-oss/concourse-github-lambda/pull/22. 