### PR TITLE
Output the role id (name)

### DIFF
--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -5,6 +5,10 @@ output "role_arn" {
   value = module.lambda.role_arn
 }
 
+output "role_name" {
+  value = module.lambda.role_name
+}
+
 output "arn" {
   value = module.lambda.arn
 }


### PR DESCRIPTION
In order to be able to attach additional policies to the role, role id needs to return.

related issue: https://github.com/terraform-providers/terraform-provider-aws/issues/3087