### PR TITLE
Setting TTL Duration for STS does not work

### DIFF
--- a/terraform/modules/team/variables.tf
+++ b/terraform/modules/team/variables.tf
@@ -18,7 +18,7 @@ variable "config_bucket" {
 
 variable "accounts" {
   description = "Valid JSON representation of a Team (see Go code)."
-  type        = list(object({ name = string, roleArn = string }))
+  type        = list(object({ name = string, roleArn = string, duration = string }))
 }
 
 variable "tags" {


### PR DESCRIPTION
Without defining duration, the module can not receive the TTL time.

Maybe even better to change the type to any to let lambda pick what it wants.

```hcl
variable "accounts" {
  description = "Valid JSON representation of a Team (see Go code)."
  type        = list(object(any))
}
```