### PR TITLE
Fix terraform example

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,8 +36,9 @@ module "team" {
 
   accounts = [
     {
-      name    = "example-account"
-      roleArn = aws_iam_role.main.arn
+      name     = "example-account"
+      roleArn  = aws_iam_role.main.arn
+      duration = 3600
     },
   ]
 }


### PR DESCRIPTION
Ref #25 and #23 it seems like we missed validating the example. `duration` is now a required variable due to: https://github.com/hashicorp/terraform/issues/19898