### PR TITLE
Fix duration type to be number

### DIFF
--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -7,7 +7,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   s3_bucket = var.filename == null && var.s3_bucket == null ? "telia-oss-${data.aws_region.current.name}" : var.s3_bucket
-  s3_key    = var.filename == null && var.s3_key == null ? "concourse-sts-lambda/v1.1.0.zip" : var.s3_key
+  s3_key    = var.filename == null && var.s3_key == null ? "concourse-sts-lambda/v1.2.0.zip" : var.s3_key
 }
 
 module "lambda" {

--- a/terraform/modules/team/variables.tf
+++ b/terraform/modules/team/variables.tf
@@ -18,7 +18,7 @@ variable "config_bucket" {
 
 variable "accounts" {
   description = "Valid JSON representation of a Team (see Go code)."
-  type        = list(object({ name = string, roleArn = string, duration = string }))
+  type        = list(object({ name = string, roleArn = string, duration = number }))
 }
 
 variable "tags" {


### PR DESCRIPTION
Ref #25 and #23 - currently terraform JSON encodes the duration as a string, which the lambda then fails to parse since its expecting an `int64` for the `duration` field. This PR fixes the issue and prepares for a `v1.2.0` release.